### PR TITLE
Small typo in R-squared description

### DIFF
--- a/notebooks/A3. Linear Regression - Analysis.ipynb
+++ b/notebooks/A3. Linear Regression - Analysis.ipynb
@@ -102,7 +102,7 @@
       "\n",
       "$R$-$squared$ or $R^2$  is a measure of how much of the variance in the data is captured by the model.  What does this mean? For now let's understand this as a measure of how well the model captures the **spread** of the observed values not just the average trend. \n",
       "\n",
-      "R is a coefficient of correlation between the independent variables and the dependent variable - i.e. how much the Y depends on the separate X's. R lies between -1 and 1, so R lies between 0 and 1. \n",
+      "R is a coefficient of correlation between the independent variables and the dependent variable - i.e. how much the Y depends on the separate X's. R lies between -1 and 1, so $R^2$ lies between 0 and 1. \n",
       "\n",
       "A high $R^2$ would be close to 1.0 a low one close to 0.  The value we have, 0.65, is a reasonably good one.  It suggests an R with absolute value in the neighborhood of 0.8.\n",
       "The details of these error estimates deserve a separate discussion which we defer until another time.\n",


### PR DESCRIPTION
Fixup "R lies between -1 and 1, so R lies between 0 and 1."
