### PR TITLE
Update B1a. Odds, LogOdds and Logit Function .ipynb: fix the odds ratio example.

### DIFF
--- a/notebooks/B1a. Odds, LogOdds and Logit Function .ipynb
+++ b/notebooks/B1a. Odds, LogOdds and Logit Function .ipynb
@@ -64,7 +64,7 @@
       "\n",
       "If OddsRatio is high say:  \n",
       "\n",
-      "$$OR > 0.75$$   \n",
+      "$$OR > 4$$   \n",
       "\n",
       "then the event might be considered very likely and if:  \n",
       "\n",


### PR DESCRIPTION
I think that was a typo. An event that is considered very likely should have odds ratio greater than zero.